### PR TITLE
Use unique query

### DIFF
--- a/pages/api/xata-global.ts
+++ b/pages/api/xata-global.ts
@@ -46,6 +46,9 @@ export default async function api(req: Request) {
   for (let i = 0; i < count; i++) {
     data = await xata.db.employees
       .select(["emp_no", "first_name", "last_name"])
+      .filter({
+        last_name: {$startsWith: String.fromCharCode(65 + i)}
+      })
       .getMany({ pagination: { size: 10 }, consistency: "eventual" });
   }
 


### PR DESCRIPTION
The demo is meant to give a realistic measurement of page  waterfall requests. However, since the query is exactly the same each time, some implementations, e.g. XATA, cache the result of the query on the client. This leads to unrealistic results since waterfall requests won't be all the same in real world scenarios.

To address, this changed the query to query for different surname prefix each time. The same change should be made to all other implementations.