### PR TITLE
Remove obfuscation of text on mobile

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -277,10 +277,10 @@ export default function Page() {
         {data.regional.length || data.global.length ? (
           <Grid className="gap-5" numCols={1} numColsMd={2}>
             <Card>
-              <Title className="truncate">
+              <Title>
                 Latency distribution (processing time)
               </Title>
-              <Text className="h-14 overflow-auto">
+              <Text>
                 This is how long it takes for the edge function to run the
                 queries and return the result. Your internet connections{' '}
                 <b>will not</b> influence these results.
@@ -307,10 +307,10 @@ export default function Page() {
               />
             </Card>
             <Card>
-              <Title className="truncate">
+              <Title>
                 Latency distribution (end-to-end)
               </Title>
-              <Text className="h-14 overflow-auto">
+              <Text>
                 This is the total latency from the client&apos;s perspective. It
                 considers the total roundtrip between browser and edge. Your
                 internet connection and location <b>will</b> influence these


### PR DESCRIPTION
The `Title` and `Text` components in the charts were truncating the title and forcing an overflow scroll on the description at mobile sizes.

This removes the offending styles and allows for better legibility on mobile

**Old**
<img width="389" alt="Screenshot 2023-04-10 at 9 10 57 PM" src="https://user-images.githubusercontent.com/1395543/231038132-9084e427-0935-4d95-b958-76f6295262fa.png">

**New**
<img width="389" alt="Screenshot 2023-04-10 at 9 11 43 PM" src="https://user-images.githubusercontent.com/1395543/231038147-b3764e13-a356-40d3-84b9-7e3bdc0816ac.png">
