### PR TITLE
Upgrade @neondatabase/serverless to 0.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@heroicons/react": "1.0.6",
     "@libsql/client": "^0.3.5",
-    "@neondatabase/serverless": "^0.6.0",
+    "@neondatabase/serverless": "^0.8.1",
     "@planetscale/database": "^1.11.0",
     "@polyscale/serverless-js": "^1.4.0",
     "@supabase/supabase-js": "^2.38.0",

--- a/pages/api/neon-global.ts
+++ b/pages/api/neon-global.ts
@@ -1,11 +1,9 @@
-import { neon, neonConfig } from "@neondatabase/serverless";
+import { neon } from "@neondatabase/serverless";
 import { NextRequest as Request, NextResponse as Response } from "next/server";
 
 export const config = {
   runtime: "edge",
 };
-
-neonConfig.fetchConnectionCache = true;
 
 const start = Date.now();
 


### PR DESCRIPTION
This version brings latency improvements:

```
0.8.0 (2024-02-06)

Use a single (per-region) domain name for all connections to Neon databases. Intended to help with connection caching in V8. Passes the endpoint ID inside connection options for WebSocket connections.
```